### PR TITLE
Retrieves the git sha from GIT_SHA if available

### DIFF
--- a/config.go
+++ b/config.go
@@ -132,6 +132,8 @@ func currentGitSha() (sha string) {
 	if len(sha) == 0 {
 		sha = simpleExec("git", "rev-parse", "HEAD")
 	}
+
+	return
 }
 
 func simpleExec(name string, arg ...string) string {


### PR DESCRIPTION
On Heroku, the directory where the app deployed is not a git repo. Instead,
we use the GIT_SHA environment variable.
