### PR TITLE
Use log file

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,9 +36,6 @@ type ConfigWrapper interface {
 
 func NewConfiguration(workingdir string) *Configuration {
 	return &Configuration{
-		App:           "",
-		Env:           "",
-		LogFile:       "",
 		AppConfigPath: filepath.Join(workingdir, ".app-config"),
 		Sha:           currentSha(workingdir),
 		PidPath:       filepath.Join(workingdir, "tmp", "pids"),

--- a/grohl.go
+++ b/grohl.go
@@ -51,14 +51,17 @@ func SetupLogger(config ConfigWrapper) {
 		writer, err := newSyslogWriter(innerconfig.SyslogAddr, innerconfig.App)
 		if err != nil {
 			grohl.Report(err, grohl.Data{"syslog": innerconfig.SyslogAddr})
+		} else {
+
+			logger = grohl.NewIoLogger(writer)
 		}
-		logger = grohl.NewIoLogger(writer)
 	} else if len(innerconfig.LogFile) > 0 {
 		file, err := os.OpenFile(innerconfig.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0755)
 		if err != nil {
 			grohl.Report(err, grohl.Data{"log_file": innerconfig.LogFile})
+		} else {
+			logger = grohl.NewIoLogger(file)
 		}
-		logger = grohl.NewIoLogger(file)
 	}
 
 	if logger == nil {

--- a/grohl.go
+++ b/grohl.go
@@ -49,9 +49,16 @@ func SetupLogger(config ConfigWrapper) {
 	var logger grohl.Logger
 	if len(innerconfig.SyslogAddr) > 0 {
 		writer, err := newSyslogWriter(innerconfig.SyslogAddr, innerconfig.App)
-		if err == nil {
-			logger = grohl.NewIoLogger(writer)
+		if err != nil {
+			grohl.Report(err, grohl.Data{"syslog": innerconfig.SyslogAddr})
 		}
+		logger = grohl.NewIoLogger(writer)
+	} else if len(innerconfig.LogFile) > 0 {
+		file, err := os.OpenFile(innerconfig.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0755)
+		if err != nil {
+			grohl.Report(err, grohl.Data{"log_file": innerconfig.LogFile})
+		}
+		logger = grohl.NewIoLogger(file)
 	}
 
 	if logger == nil {

--- a/grohl.go
+++ b/grohl.go
@@ -52,7 +52,6 @@ func SetupLogger(config ConfigWrapper) {
 		if err != nil {
 			grohl.Report(err, grohl.Data{"syslog": innerconfig.SyslogAddr})
 		} else {
-
 			logger = grohl.NewIoLogger(writer)
 		}
 	} else if len(innerconfig.LogFile) > 0 {


### PR DESCRIPTION
This uses the given `APP_LOG_FILE` value to open a file for logging. Not recommended, since the file handle is unmanaged. 
